### PR TITLE
Made use of standard library consistent

### DIFF
--- a/Chapter_8/Assignments 8.1 and 8.2/Assignments_8.1_8.2_Mac.cpp
+++ b/Chapter_8/Assignments 8.1 and 8.2/Assignments_8.1_8.2_Mac.cpp
@@ -3,7 +3,6 @@
 // Copyright (c) 2017 Hall & Slonka
 
 #include <iostream>
-using namespace std;
 
 extern "C" void asmMain();
 
@@ -19,7 +18,7 @@ extern "C" void printString(char* s){
 }
 
 extern "C" void printDouble(double d){
-    cout << d << endl;
+    std::cout << d << std::endl;
 }
 
 // main stub driver

--- a/Chapter_8/Assignments 8.1 and 8.2/Assignments_8.1_8.2_Win_Linux.cpp
+++ b/Chapter_8/Assignments 8.1 and 8.2/Assignments_8.1_8.2_Win_Linux.cpp
@@ -3,7 +3,6 @@
 // Copyright (c) 2017 Hall & Slonka
 
 #include <iostream>
-using namespace std;
 
 extern "C" void _asmMain();
 
@@ -19,7 +18,7 @@ extern "C" void _printString(char* s) {
 }
 
 extern "C" void _printDouble(double d) {
-    cout << d << endl;
+    std::cout << d << std::endl;
 }
 
 // main stub driver


### PR DESCRIPTION
Half of the I/O statements had the std:: prefix and half didn't since you were using namespace std. I just made it consistent